### PR TITLE
Respect `hostnameOverride`.

### DIFF
--- a/deploy/kubernetes/che-devfile-registry/templates/_template.tpl
+++ b/deploy/kubernetes/che-devfile-registry/templates/_template.tpl
@@ -1,0 +1,3 @@
+{{- define "devfile.hostname" -}}
+{{- .Values.hostnameOverride | default (printf "che-plugin-registry-%s" .Release.Namespace) -}}
+{{- end -}}

--- a/deploy/kubernetes/che-devfile-registry/templates/configmap.yaml
+++ b/deploy/kubernetes/che-devfile-registry/templates/configmap.yaml
@@ -17,4 +17,4 @@ data:
   {{ with .organization -}} CHE_DEVFILE_IMAGES_REGISTRY_ORGANIZATION: {{ . }} {{- end }}
   {{ with .tag -}} CHE_DEVFILE_IMAGES_REGISTRY_TAG: {{ . }} {{- end }}
   {{ end -}}
-  CHE_DEVFILE_REGISTRY_URL: http{{- if .Values.cheDevfileRegistryIngressSecretName -}}s{{- end -}}{{- printf "://che-devfile-registry-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
+  CHE_DEVFILE_REGISTRY_URL: http{{- if .Values.cheDevfileRegistryIngressSecretName -}}s{{- end -}} :// {{- template "devfile.hostname" . -}} . {{- .Values.global.ingressDomain }}

--- a/deploy/kubernetes/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/che-devfile-registry/templates/ingress.yaml
@@ -1,6 +1,3 @@
-{{- define "hostname" -}}
-{{- .Values.hostnameOverride | default (printf "che-plugin-registry-%s" .Release.Namespace) -}}
-{{- end -}}
 #
 # Copyright (c) 2018-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -18,7 +15,7 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.global.ingress.class }}
 spec:
   rules:
-  - host: {{ template "hostname" . -}} . {{- .Values.global.ingressDomain }}
+  - host: {{ template "devfile.hostname" . -}} . {{- .Values.global.ingressDomain }}
     http:
       paths:
       - path: /
@@ -28,6 +25,6 @@ spec:
 {{- if .Values.cheDevfileRegistryIngressSecretName }}
   tls:
   - hosts:
-    - {{ template "hostname" . -}} . {{- .Values.global.ingressDomain }}
+    - {{ template "devfile.hostname" . -}} . {{- .Values.global.ingressDomain }}
     secretName: {{ .Values.cheDevfileRegistryIngressSecretName }}
 {{- end -}}


### PR DESCRIPTION
ConfigMap doesn't respect `hostnameOverride` even though Ingress does.