### PR TITLE
fix(entrypoint): upstream tag image has been updated

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -30,8 +30,9 @@ RUN ./list_referenced_images.sh devfiles > /build/devfiles/external_images.txt
 RUN chmod -R g+rwX /build/devfiles
 
 FROM docker.io/httpd:2.4.43-alpine AS registry
-# Allow htaccess
-RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
+RUN apk add --no-cache bash && \
+    # Allow htaccess
+    sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
     sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \
     mkdir -m 777 /usr/local/apache2/htdocs/devfiles && \
     mkdir -p /var/www && ln -s /usr/local/apache2/htdocs /var/www/html && \


### PR DESCRIPTION
https://github.com/docker-library/httpd/commit/ea20f356a6f7d5b22793d0a51d82d6fccd08a6aa

it removes build dependencies but we were using bash transitively and it fails
add bash

good news: the image is A LOT smaller !

Change-Id: Id69a992a971414b6d64416ab9aaf9741b17dcca1
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?


### What issues does this PR fix or reference?
